### PR TITLE
[wifi_manager] act as a captive portal when in AP mode

### DIFF
--- a/examples/blink/blink.cpp
+++ b/examples/blink/blink.cpp
@@ -5,6 +5,7 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <ArduinoOTA.h>
+#include <DNSServer.h>
 #include <LittleFS.h>
 // This is the relevant include file for using the library.
 #include <og3/app.h>

--- a/include/og3/wifi_manager.h
+++ b/include/og3/wifi_manager.h
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#ifndef NATIVE
 #include <DNSServer.h>
+#endif
 
 #include <functional>
 #include <memory>
@@ -87,7 +89,9 @@ class WifiManager : public Module {
   void onWifiEvent(arduino_event_id_t task, arduino_event_info_t info);
 #endif
 
-  std::unique_ptr<DNSServer> m_dnsServer;
+#ifndef NATIVE
+  std::unique_ptr<DNSServer> m_dns_server;
+#endif
   SingleDependency m_dependencies;
   TaskScheduler m_scheduler;
   TaskScheduler m_status_scheduler;

--- a/include/og3/wifi_manager.h
+++ b/include/og3/wifi_manager.h
@@ -3,10 +3,6 @@
 
 #pragma once
 
-#ifndef NATIVE
-#include <DNSServer.h>
-#endif
-
 #include <functional>
 #include <memory>
 
@@ -19,6 +15,7 @@
 #include "og3/wifi.h"
 
 class AsyncWebServerRequest;
+class DNSServer;
 
 namespace og3 {
 

--- a/include/og3/wifi_manager.h
+++ b/include/og3/wifi_manager.h
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include <DNSServer.h>
+
 #include <functional>
+#include <memory>
 
 #include "og3/compiler_definitions.h"
 #include "og3/constants.h"
@@ -64,6 +67,9 @@ class WifiManager : public Module {
   void addDisconnectCallback(const std::function<void()>& callback) {
     m_disconnectCallbacks.push_back(callback);
   }
+  void addSoftAPCallback(const std::function<void()>& callback) {
+    m_softAPCallbacks.push_back(callback);
+  }
 
   static WifiManager* get(const NameToModule& n2m) { return GetModule<WifiManager>(n2m, kName); }
 
@@ -81,6 +87,7 @@ class WifiManager : public Module {
   void onWifiEvent(arduino_event_id_t task, arduino_event_info_t info);
 #endif
 
+  std::unique_ptr<DNSServer> m_dnsServer;
   SingleDependency m_dependencies;
   TaskScheduler m_scheduler;
   TaskScheduler m_status_scheduler;
@@ -99,6 +106,7 @@ class WifiManager : public Module {
 
   std::vector<std::function<void()>> m_connectCallbacks;
   std::vector<std::function<void()>> m_disconnectCallbacks;
+  std::vector<std::function<void()>> m_softAPCallbacks;
 #ifdef ARDUINO_ARCH_ESP32
   WiFiEventId_t m_wifiEventIdConnected;
   WiFiEventId_t m_wifiEventIdDisconnected;

--- a/include/og3/wifi_manager.h
+++ b/include/og3/wifi_manager.h
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#ifndef NATIVE
+#include <DNSServer.h>
+#endif
+
 #include <functional>
 #include <memory>
 
@@ -15,7 +19,6 @@
 #include "og3/wifi.h"
 
 class AsyncWebServerRequest;
-class DNSServer;
 
 namespace og3 {
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,9 @@ build_flags =
 	'-Wno-deprecated'
 ;	'-std=gnu++17'
 lib_deps =
-	me-no-dev/ESP Async WebServer@1.2.3
+	https://github.com/mathieucarbou/ESPAsyncWebServer
+        ; This seems no longer maintained.
+	; me-no-dev/ESP Async WebServer@1.2.3
 	bblanchon/ArduinoJson@^7.0.0
 	ottowinter/AsyncMqttClient-esphome@ ^0.8.5
 	esphome/ESPAsyncWebServer-esphome@^3.0.0
@@ -41,6 +43,8 @@ build_type = debug
 framework = arduino
 build_src_filter = +<src/*>
 monitor_speed = 115200
+uploadProtocol = esptool
+uploadPort = /dev/ttyUSB0
 
 [esp32_base]
 extends = esp_base
@@ -110,4 +114,4 @@ extends = env:esp32dev, wifi_app_base
 extends = env:esp32dev, web_app_base
 
 [env:esp32dev_ha_app]
-extends = env:esp32dev
+extends = env:esp32dev, ha_app_base

--- a/src/mqtt_manager.cpp
+++ b/src/mqtt_manager.cpp
@@ -175,9 +175,7 @@ void MqttManager::subscribe(const String& topic, const MqttMsgCallbackFn& fn) {
 void MqttManager::handleRequest(AsyncWebServerRequest* request, const char* title,
                                 const char* footer) {
 #ifndef NATIVE
-  if (request->method() == HTTP_POST) {
-    read(*request, &m_vg);
-  }
+  read(*request, &m_vg);
   String form;
   html::writeFormTableInto(&form, m_vg);
   form += F(HTML_BUTTON("/", "Back"));

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -5,6 +5,10 @@
 
 #include <functional>
 
+#ifndef NATIVE
+#include <DNSServer.h>
+#endif
+
 #include "og3/config_interface.h"
 #include "og3/constants.h"
 #include "og3/html_table.h"


### PR DESCRIPTION
- Upgrade to a maintained version of ESPAsyncWebServer: https://github.com/mathieucarbou/ESPAsyncWebServer
    -  Check `request->method() == HTTP_POST` no longer works
- Add web-buttons for restarting the example apps
- `WiFi.persistent(false);` apparently saves the flash by not writing Wifi ESSID/password on each reboot