### PR TITLE
version -> 0.2.0

### DIFF
--- a/examples/ha-app/ha-app.cpp
+++ b/examples/ha-app/ha-app.cpp
@@ -47,7 +47,7 @@ class Blink : public og3::Module {
       : og3::Module("blink", &app->module_system()),
         m_app(app),
         m_vg("blink"),
-        m_high("led_on", false, "LED is on", &m_vg),
+        m_high("led_on", false, "LED is on", m_vg),
         // Blink every 10 second, starting at first millisecond.
         m_blink_timing(
             1, 10 * og3::kMsecInSec, [this]() { blink(); }, &app->tasks()) {

--- a/include/og3/adc.h
+++ b/include/og3/adc.h
@@ -21,7 +21,7 @@ class Adc : public Module {
   static constexpr unsigned kMaxCounts = kResolution - 1;
 
   Adc(const char* name_, uint8_t pin_, ModuleSystem* module_system_, const char* description,
-      unsigned var_flags, VariableGroup* vg);
+      unsigned var_flags, VariableGroup& vg);
 
   Adc(const Adc&) = delete;
 

--- a/include/og3/config_interface.h
+++ b/include/og3/config_interface.h
@@ -19,7 +19,7 @@ class ConfigInterface : public Module {
   static const char* kName;  // module name
 
   explicit ConfigInterface(ModuleSystem* module_system) OG3_NONNULL();
-  bool read_config(VariableGroup* var_group, const char* filename = nullptr) OG3_NONNULL((1));
+  bool read_config(VariableGroup& var_group, const char* filename = nullptr) OG3_NONNULL((1));
   bool write_config(const VariableGroup& var_group, const char* filename = nullptr)
       OG3_NONNULL((1));
 

--- a/include/og3/din.h
+++ b/include/og3/din.h
@@ -12,7 +12,7 @@ namespace og3 {
 class DIn : public Module {
  public:
   DIn(const char* name_, ModuleSystem* module_system_, uint8_t pin_, const char* description,
-      VariableGroup* vg, bool publish = true, bool invert = false);
+      VariableGroup& vg, bool publish = true, bool invert = false);
 
   // Read the dio pin and return isHigh().
   bool read();

--- a/include/og3/dout.h
+++ b/include/og3/dout.h
@@ -12,7 +12,7 @@ namespace og3 {
 class DOut : public Module {
  public:
   DOut(const char* name_, bool initial_val, ModuleSystem* module_system_, uint8_t pin_,
-       const char* description, bool publish, VariableGroup* vg);
+       const char* description, bool publish, VariableGroup& vg);
 
   void set(bool is_high);
 

--- a/include/og3/ha_discovery.h
+++ b/include/og3/ha_discovery.h
@@ -38,10 +38,12 @@ extern const char* kSignalStrength;
 extern const char* kVoltage;
 }  // namespace sensor
 namespace binary_sensor {
+extern const char* kGarage;
+extern const char* kLight;
 extern const char* kMoisture;
 extern const char* kMotion;
 extern const char* kPower;
-extern const char* kLight;
+extern const char* kPresence;
 }  // namespace binary_sensor
 }  // namespace ha::device_class
 
@@ -86,6 +88,10 @@ class HADiscovery : public Module {
     const char* subject_topic = nullptr;
     const char* device_name = nullptr;
     const char* icon = nullptr;
+    // Command subject, if applicable
+    const char* command = nullptr;
+    // Callback to be registered for 'command', if set.
+    MqttManager::MqttMsgCallbackFn command_callback;
     ValueTemplateFn value_template_fn;
   };
   bool addEntry(JsonDocument* json, const Entry& entry);

--- a/include/og3/kernel_filter.h
+++ b/include/og3/kernel_filter.h
@@ -29,7 +29,7 @@ class KernelFilter {
     size_t size;              // The number of samples used for the smoothing kernel.
   };
 
-  KernelFilter(const Options& options, ModuleSystem* module_system_, VariableGroup* vg);
+  KernelFilter(const Options& options, ModuleSystem* module_system_, VariableGroup& vg);
 
   float value() const { return m_value.value(); }
   float kernelValue(float dt) const { return exp(m_exp_scalar * dt * dt); }

--- a/include/og3/mapped_analog_sensor.h
+++ b/include/og3/mapped_analog_sensor.h
@@ -31,8 +31,8 @@ class MappedAnalogSensor {
     unsigned valid_in_max;        // If the input reads more than this, the reading is invalid.
   };
 
-  MappedAnalogSensor(const Options& options, ModuleSystem* module_system_, VariableGroup* cfgvg,
-                     VariableGroup* vg);
+  MappedAnalogSensor(const Options& options, ModuleSystem* module_system_, VariableGroup& cfgvg,
+                     VariableGroup& vg);
 
   float map(int inval) const;
   float read();

--- a/include/og3/motion_detector.h
+++ b/include/og3/motion_detector.h
@@ -12,7 +12,7 @@ namespace og3 {
 class MotionDetector : public DIn {
  public:
   MotionDetector(const char* name, ModuleSystem* module_system, uint8_t pin,
-                 const char* description, VariableGroup* vg, bool publish = true,
+                 const char* description, VariableGroup& vg, bool publish = true,
                  bool ha_discovery = true);
 
  private:

--- a/include/og3/mqtt_manager.h
+++ b/include/og3/mqtt_manager.h
@@ -77,7 +77,7 @@ class MqttManager : public Module {
 
   void mqttSend(const char topic[], const char content[]);
   bool mqttSend(const VariableGroup& variables, unsigned flags = VariableBase::kNoPublish);
-
+  // arguments: (const char* topic, const char* payload, size_t len) {
   using MqttMsgCallbackFn = std::function<void(const char*, const char*, size_t)>;
   void subscribe(const String& topic, const MqttMsgCallbackFn& fn);
 

--- a/include/og3/pid.h
+++ b/include/og3/pid.h
@@ -45,7 +45,7 @@ class PID {
     float command_max = -1.0e10;  // The maximum allowed output value.
   };
 
-  PID(const Gains& gains, VariableGroup* vg, VariableGroup* cfg_vg, VariableGroup* cmd_vg);
+  PID(const Gains& gains, VariableGroup& vg, VariableGroup& cfg_vg, VariableGroup& cmd_vg);
 
   void initialize() {
     m_last_msec = millis();

--- a/include/og3/pir.h
+++ b/include/og3/pir.h
@@ -16,7 +16,7 @@ namespace og3 {
 class Pir : public Module {
  public:
   Pir(const char* module_name, const char* motion_name, ModuleSystem* module_system, Tasks* tasks,
-      uint8_t pin, const char* description, VariableGroup* vg, bool publish, bool ha_discovery);
+      uint8_t pin, const char* description, VariableGroup& vg, bool publish, bool ha_discovery);
 
   void read();
 

--- a/include/og3/relay.h
+++ b/include/og3/relay.h
@@ -17,7 +17,7 @@ class Relay : public DOut {
   };
 
   Relay(const char* name_, Tasks* tasks, uint8_t pin_, const char* description, bool publish,
-        VariableGroup* vg, OnLevel on_level = OnLevel::kHigh);
+        VariableGroup& vg, OnLevel on_level = OnLevel::kHigh);
 
   bool turnOn(int on_msec = 0, const std::function<void()>& off_fn = nullptr);
   void turnOffIn(int msec, const std::function<void()>& fn = nullptr);

--- a/include/og3/sonar.h
+++ b/include/og3/sonar.h
@@ -19,7 +19,7 @@ constexpr float kSecPerUsec = 1e-6;
 // This was used with a HC-SR04 sensor.
 class Sonar : public Module {
  public:
-  Sonar(const char* name, int trigPin, int echoPin, ModuleSystem* module_system, VariableGroup* vg,
+  Sonar(const char* name, int trigPin, int echoPin, ModuleSystem* module_system, VariableGroup& vg,
         bool ha_discovery = true);
 
   void setTemp(float tempC);

--- a/include/og3/temp_humidity.h
+++ b/include/og3/temp_humidity.h
@@ -18,7 +18,7 @@ namespace og3 {
 class TempHumidity : public Module {
  public:
   TempHumidity(const char* temp_name, const char* humidity_name, ModuleSystem* module_system_,
-               const char* description, VariableGroup* vg, bool publish = true,
+               const char* description, VariableGroup& vg, bool publish = true,
                bool ha_discovery = true);
 
   bool ok() const { return m_ok; }

--- a/include/og3/web_server.h
+++ b/include/og3/web_server.h
@@ -15,8 +15,8 @@ class VariableBase;
 class VariableGroup;
 
 #ifndef NATIVE
-bool read(const AsyncWebServerRequest& request, VariableBase* var);
-bool read(const AsyncWebServerRequest& request, VariableGroup* var_group);
+bool read(const AsyncWebServerRequest& request, VariableBase& var);
+bool read(const AsyncWebServerRequest& request, const VariableGroup& var_group);
 
 // A module for managing a AsyncWebServer.
 class WebServer : public Module {

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "og3",
-    "version": "0.1.6",
+    "version": "0.2.0",
     "description": "A library for esp projects",
     "keywords": "esp32, esp8266, modules, tasks, mqtt",
     "authors": [

--- a/src/adc.cpp
+++ b/src/adc.cpp
@@ -10,7 +10,7 @@
 namespace og3 {
 
 Adc::Adc(const char* name_, uint8_t pin_, ModuleSystem* module_system_, const char* description,
-         unsigned var_flags, VariableGroup* vg)
+         unsigned var_flags, VariableGroup& vg)
     : Module(name_, module_system_),
       m_pin(pin_),
       m_counts(name_, false, "counts", description, var_flags, vg) {

--- a/src/app_status.cpp
+++ b/src/app_status.cpp
@@ -19,8 +19,8 @@ AppStatus::AppStatus(Tasks* tasks)
     : Module(kName, tasks->module_system()),
       m_tasks(tasks),
       m_vg(kName),
-      m_mem_available("mem_avail", 0.0f, units::kKilobytes, "memory available", 0, 1, &m_vg),
-      m_uptime_msec("uptime", 0, units::kMilliseconds, "uptime", 0, &m_vg) {
+      m_mem_available("mem_avail", 0.0f, units::kKilobytes, "memory available", 0, 1, m_vg),
+      m_uptime_msec("uptime", 0, units::kMilliseconds, "uptime", 0, m_vg) {
   add_link_fn([this](const NameToModule& name_to_module) -> bool {
     m_mqtt_manager = MqttManager::get(name_to_module);
     return true;

--- a/src/config_interface.cpp
+++ b/src/config_interface.cpp
@@ -90,7 +90,7 @@ ConfigInterface::ConfigInterface(ModuleSystem* module_system)
 
 Logger* ConfigInterface::log() { return module_system()->log(); }
 
-bool ConfigInterface::read_config(VariableGroup* var_group, const char* filename) {
+bool ConfigInterface::read_config(VariableGroup& var_group, const char* filename) {
   // Make sure flash is setup.
   if (!m_fs || !m_fs->setup()) {
     return false;
@@ -100,7 +100,7 @@ bool ConfigInterface::read_config(VariableGroup* var_group, const char* filename
   if (filename) {
     snprintf(fname, sizeof(fname), "%s%s", kFSRoot, filename);
   } else {
-    snprintf(fname, sizeof(fname), "%s%s.json", kFSRoot, var_group->name());
+    snprintf(fname, sizeof(fname), "%s%s.json", kFSRoot, var_group.name());
   }
 
   if (!LittleFS.exists(fname)) {
@@ -115,7 +115,7 @@ bool ConfigInterface::read_config(VariableGroup* var_group, const char* filename
   log()->debugf("Reading config file '%s'.", fname);
   JsonDocument doc;
   deserializeJson(doc, config_file);
-  for (auto* var : var_group->variables()) {
+  for (auto* var : var_group.variables()) {
     if (!var->config()) {
       continue;
     }

--- a/src/din.cpp
+++ b/src/din.cpp
@@ -10,7 +10,7 @@
 namespace og3 {
 
 DIn::DIn(const char* name_, ModuleSystem* module_system_, uint8_t pin_, const char* description,
-         VariableGroup* vg, bool publish, bool invert)
+         VariableGroup& vg, bool publish, bool invert)
     : Module(name_, module_system_),
       m_pin(pin_),
       m_invert(invert),

--- a/src/dout.cpp
+++ b/src/dout.cpp
@@ -11,7 +11,7 @@ namespace og3 {
 const char* strHigh(bool high) { return high ? "high" : "low"; }
 
 DOut::DOut(const char* name_, bool initial_val, ModuleSystem* module_system_, uint8_t pin_,
-           const char* description, bool publish, VariableGroup* vg)
+           const char* description, bool publish, VariableGroup& vg)
     : Module(name_, module_system_),
       m_pin(pin_),
       m_is_high(name_, false, description, vg, publish) {

--- a/src/ha_app.cpp
+++ b/src/ha_app.cpp
@@ -17,7 +17,7 @@ void HAApp::setup() { WebApp::setup(); }
 
 void HAApp::handleMqttConfigRequest(AsyncWebServerRequest* request) {
 #ifndef NATIVE
-  ::og3::read(*request, &mqtt_manager().mutableVariables());
+  ::og3::read(*request, mqtt_manager().mutableVariables());
   m_web_page.clear();
   html::writeFormTableInto(&m_web_page, mqtt_manager().variables());
   m_web_page += F(HTML_BUTTON("/", "Back"));

--- a/src/ha_discovery.cpp
+++ b/src/ha_discovery.cpp
@@ -41,10 +41,12 @@ const char* kVoltage = "voltage";
 }  // namespace sensor
 
 namespace binary_sensor {
+const char* kGarage = "garage";
+const char* kLight = "light";
 const char* kMoisture = "moisture";
 const char* kMotion = "motion";
 const char* kPower = "power";
-const char* kLight = "light";
+const char* kPresence = "presence";
 }  // namespace binary_sensor
 }  // namespace ha::device_class
 
@@ -163,12 +165,8 @@ bool HADiscovery::addEntry(JsonDocument* json, const HADiscovery::Entry& entry) 
   }
   {
     const char* subject = entry.subject_topic ? entry.subject_topic : "~";
-    if (!entry.var.group()) {
-      js["stat_t"] = subject;
-    } else {
-      snprintf(value, sizeof(value), "%s/%s", subject, entry.var.group()->name());
-      js["stat_t"] = value;
-    }
+    snprintf(value, sizeof(value), "%s/%s", subject, entry.var.group().name());
+    js["stat_t"] = value;
   }
 #ifdef NATIVE
   js["val_tpl"] = entry.value_template_fn(entry).c_str();
@@ -183,6 +181,13 @@ bool HADiscovery::addEntry(JsonDocument* json, const HADiscovery::Entry& entry) 
   js["uniq_id"] = value;
   if (entry.icon) {
     js["ic"] = entry.icon;
+  }
+  if (entry.command) {
+    snprintf(value, sizeof(value), "~/%s", entry.command);
+    js["cmd_t"] = value;
+    if (entry.command_callback) {
+      mqttSubscribe(entry.command, entry.command_callback);
+    }
   }
   return mqttSendConfig(entry.var.name(), entry.device_type, json);
 }

--- a/src/kernel_filter.cpp
+++ b/src/kernel_filter.cpp
@@ -5,7 +5,7 @@
 
 namespace og3 {
 
-KernelFilter::KernelFilter(const Options& options, ModuleSystem* module_system_, VariableGroup* vg)
+KernelFilter::KernelFilter(const Options& options, ModuleSystem* module_system_, VariableGroup& vg)
     : m_value(options.name, 0.0f, options.units, options.description, options.var_flags,
               options.decimals, vg),
       m_sigma(-100.0f),

--- a/src/mapped_analog_sensor.cpp
+++ b/src/mapped_analog_sensor.cpp
@@ -6,7 +6,7 @@
 namespace og3 {
 
 MappedAnalogSensor::MappedAnalogSensor(const Options& options, ModuleSystem* module_system_,
-                                       VariableGroup* cfg_vg, VariableGroup* vg)
+                                       VariableGroup& cfg_vg, VariableGroup& vg)
     : m_valid_in_min(options.valid_in_min),
       m_valid_in_max(options.valid_in_max),
       m_name(options.name),

--- a/src/motion_detector.cpp
+++ b/src/motion_detector.cpp
@@ -6,7 +6,7 @@
 namespace og3 {
 
 MotionDetector::MotionDetector(const char* name, ModuleSystem* module_system, uint8_t pin,
-                               const char* description, VariableGroup* vg, bool publish,
+                               const char* description, VariableGroup& vg, bool publish,
                                bool ha_discovery)
     : DIn(name, module_system, pin, description, vg, publish) {
   if (ha_discovery) {

--- a/src/mqtt_manager.cpp
+++ b/src/mqtt_manager.cpp
@@ -51,21 +51,21 @@ MqttManager::MqttManager(const Options& opts, Tasks* tasks)
       m_dependency(WifiManager::kName),
       m_vg(kName, VariableGroup::VarNameType::kBase, 4),
       m_host_addr("host", opts.default_server, "", "MQTT server",
-                  VariableBase::kConfig | VariableBase::kSettable, &m_vg),
+                  VariableBase::kConfig | VariableBase::kSettable, m_vg),
 #if 0
       m_port("port", opts.port, "", "port",
-                  VariableBase::kConfig | VariableBase::kSettable | VariableBase::kNoPublish, &m_vg),
+                  VariableBase::kConfig | VariableBase::kSettable | VariableBase::kNoPublish, m_vg),
 #endif
       m_auth_user("user", opts.default_user, "", "username",
-                  VariableBase::kConfig | VariableBase::kSettable, &m_vg),
+                  VariableBase::kConfig | VariableBase::kSettable, m_vg),
       m_auth_password("password", opts.default_password, "", "password",
                       VariableBase::kConfig | VariableBase::kSettable | VariableBase::kNoPublish |
                           VariableBase::kNoDisplay,
-                      &m_vg),
+                      m_vg),
       m_mode("mode", opts.mode, "", "mode", Mode::kHomeAssistant, Mode::kAdafruitIO, s_str_modes,
-             VariableBase::kConfig | VariableBase::kSettable | VariableBase::kNoPublish, &m_vg),
+             VariableBase::kConfig | VariableBase::kSettable | VariableBase::kNoPublish, m_vg),
       m_connected("connection", kNotConnected, "", "connection", kNotConnected, kConnected,
-                  s_str_connected, VariableBase::kNoPublish, &m_vg) {
+                  s_str_connected, VariableBase::kNoPublish, m_vg) {
   // Module callbacks
   setDependencies(&m_dependency);
   add_link_fn([this](NameToModule& name_to_module) -> bool {
@@ -75,7 +75,7 @@ MqttManager::MqttManager(const Options& opts, Tasks* tasks)
   });
   add_init_fn([this]() {
     if (m_config) {
-      m_config->read_config(&m_vg);
+      m_config->read_config(m_vg);
     }
     if (m_wifi_manager) {
       m_wifi_manager->addConnectCallback([this] { connect(); });

--- a/src/ota_manager.cpp
+++ b/src/ota_manager.cpp
@@ -21,7 +21,7 @@ OtaManager::OtaManager(const Options& opts, ModuleSystem* module_system)
       m_dependencies({WifiManager::kName, ConfigInterface::kName}),
       m_vg(kName),
       m_password("password", opts.default_password, "", "password",
-                 VariableBase::kConfig | VariableBase::kSettable, &m_vg) {
+                 VariableBase::kConfig | VariableBase::kSettable, m_vg) {
   setDependencies(&m_dependencies);
   add_link_fn([this](NameToModule& name_to_module) -> bool {
     m_config = ConfigInterface::get(name_to_module);
@@ -32,7 +32,7 @@ OtaManager::OtaManager(const Options& opts, ModuleSystem* module_system)
     if (!m_config || !m_wifi_manager) {
       return;
     }
-    m_config->read_config(&m_vg);
+    m_config->read_config(m_vg);
     setup();
   });
 #ifndef NATIVE

--- a/src/pid.cpp
+++ b/src/pid.cpp
@@ -10,7 +10,7 @@ constexpr unsigned kCfgSet = VariableBase::Flags::kConfig | VariableBase::Flags:
 constexpr unsigned kOutputSet = 0;
 }  // namespace
 
-PID::PID(const PID::Gains& gains, VariableGroup* vg, VariableGroup* cfg_vg, VariableGroup* cmd_vg)
+PID::PID(const PID::Gains& gains, VariableGroup& vg, VariableGroup& cfg_vg, VariableGroup& cmd_vg)
     : m_p("p", gains.p, "", "proportional gain", kCfgSet, 2, cfg_vg),
       m_i("i", gains.i, "", "integral gain", kCfgSet, 5, cfg_vg),
       m_d("d", gains.d, "", "derivative gain", kCfgSet, 2, cfg_vg),

--- a/src/pir.cpp
+++ b/src/pir.cpp
@@ -19,7 +19,7 @@ bool Pir::s_interrupt_setup = false;
 std::function<void()> Pir::s_motion_callback;
 
 Pir::Pir(const char* module_name, const char* motion_name, ModuleSystem* module_system,
-         Tasks* tasks, uint8_t pin, const char* description, VariableGroup* vg, bool publish,
+         Tasks* tasks, uint8_t pin, const char* description, VariableGroup& vg, bool publish,
          bool ha_discovery)
     : Module(module_name, module_system),
       m_din(motion_name, module_system, pin, description, vg, publish) {

--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -8,7 +8,7 @@
 namespace og3 {
 
 Relay::Relay(const char* name_, Tasks* tasks, uint8_t pin_, const char* description, bool publish,
-             VariableGroup* vg, OnLevel on_level)
+             VariableGroup& vg, OnLevel on_level)
     : DOut(name_, false, tasks->module_system(), pin_, description, publish, vg),
       m_on_level(on_level),
       m_tasks(tasks) {

--- a/src/sonar.cpp
+++ b/src/sonar.cpp
@@ -9,7 +9,7 @@ namespace og3 {
 
 // m/s (dry air)
 Sonar::Sonar(const char* name, int trigPin, int echoPin, ModuleSystem* module_system,
-             VariableGroup* vg, bool ha_discovery)
+             VariableGroup& vg, bool ha_discovery)
     : Module(name, module_system),
       m_trigPin(trigPin),
       m_echoPin(echoPin),

--- a/src/temp_humidity.cpp
+++ b/src/temp_humidity.cpp
@@ -8,7 +8,7 @@
 namespace og3 {
 
 TempHumidity::TempHumidity(const char* temp_name, const char* humidity_name,
-                           ModuleSystem* module_system_, const char* description, VariableGroup* vg,
+                           ModuleSystem* module_system_, const char* description, VariableGroup& vg,
                            bool publish, bool ha_discovery)
     : Module(temp_name, module_system_),
       m_temperature(temp_name, 0.0f, units::kCelsius, description,

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -9,12 +9,12 @@
 
 namespace og3 {
 namespace {
-std::unique_ptr<String> variable_name(const char* var_name, const VariableGroup* group) {
-  if (!group || group->varname_type() != VariableGroup::VarNameType::kWithGroup) {
+std::unique_ptr<String> variable_name(const char* var_name, const VariableGroup& group) {
+  if (group.varname_type() != VariableGroup::VarNameType::kWithGroup) {
     return nullptr;
   }
   std::unique_ptr<String> ret(new String());
-  *ret = String(group->name()) + "_" + var_name;
+  *ret = String(group.name()) + "_" + var_name;
   return ret;
 }
 }  // namespace
@@ -72,22 +72,20 @@ void VariableGroup::toJson(std::ostream* out_str, unsigned flags) const {
 }
 
 VariableBase::VariableBase(const char* name_, const char* units_, const char* description_,
-                           unsigned flags_, VariableGroup* group)
+                           unsigned flags_, VariableGroup& group)
     : m_name_string(variable_name(name_, group)),
       m_name(m_name_string ? m_name_string->c_str() : name_),
       m_units(units_),
       m_description(description_),
       m_flags(flags_),
       m_group(group) {
-  if (m_group) {
-    m_group->add(this);
-  }
+  group.add(this);
 }
 
 EnumStrVariableBase::EnumStrVariableBase(const char* name_, int value, const char* units_,
                                          const char* description_, int min_value, int max_value,
                                          const char* value_names[], unsigned flags_,
-                                         VariableGroup* group)
+                                         VariableGroup& group)
     : EnumVariableBase(name_, units_, description_, flags_, group),
       m_min_value(min_value),
       m_max_value(max_value),
@@ -207,6 +205,12 @@ String BoolVariable::formEntry() const {
   };
   return String("<p>") + human_str() + radio("true", value()) + "\n" + radio("false", !value()) +
          "</p>\n";
+}
+
+BinaryCoverSensorVariable& BinaryCoverSensorVariable::operator=(bool value) {
+  m_value = value;
+  setFailed(false);
+  return *this;
 }
 
 }  // namespace og3

--- a/src/web_app.cpp
+++ b/src/web_app.cpp
@@ -27,7 +27,7 @@ WebApp::WebApp(const WifiApp::Options& options) : WifiApp(options), m_web_server
 
 void WebApp::handleWifiConfigRequest(AsyncWebServerRequest* request) {
 #ifndef NATIVE
-  ::og3::read(*request, &wifi_manager().mutableVariables());
+  ::og3::read(*request, wifi_manager().mutableVariables());
   m_web_page.clear();
   html::writeFormTableInto(&m_web_page, wifi_manager().variables());
   m_web_page += F(HTML_BUTTON("/", "Back"));

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -11,17 +11,17 @@ namespace og3 {
 #ifndef NATIVE
 const char* WebServer::kName = "web_server";
 
-bool read(const AsyncWebServerRequest& request, VariableBase* var) {
-  if (!request.hasParam(var->name(), true)) {
+bool read(const AsyncWebServerRequest& request, VariableBase& var) {
+  if (!request.hasParam(var.name(), true)) {
     return false;
   }
-  return var->fromString(request.getParam(var->name(), true)->value());
+  return var.fromString(request.getParam(var.name(), true)->value());
 }
-bool read(const AsyncWebServerRequest& request, VariableGroup* var_group) {
+bool read(const AsyncWebServerRequest& request, const VariableGroup& var_group) {
   bool ret = true;
-  for (auto* var : var_group->variables()) {
+  for (auto* var : var_group.variables()) {
     if (var->settable()) {
-      ret = read(request, var) && ret;
+      ret = read(request, *var) && ret;
     }
   }
   return ret;

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -80,15 +80,15 @@ WifiManager::WifiManager(const char* default_board_name, Tasks* tasks,
       m_scheduler(tasks),
       m_vg(kName, VariableGroup::VarNameType::kBase, 4),
       m_board("board", default_board_name, "", "Device name",
-              VariableBase::kConfig | VariableBase::kSettable, &m_vg),
+              VariableBase::kConfig | VariableBase::kSettable, m_vg),
       m_essid("essid", nullToEmpty(options.default_essid), "", "",
-              VariableBase::kConfig | VariableBase::kSettable | VariableBase::kNoPublish, &m_vg),
+              VariableBase::kConfig | VariableBase::kSettable | VariableBase::kNoPublish, m_vg),
       m_password("password", nullToEmpty(options.default_password), "", "",
                  VariableBase::kConfig | VariableBase::kSettable | VariableBase::kNoPublish |
                      VariableBase::kNoDisplay,
-                 &m_vg),
-      m_ip_addr("ip", "", "", "", 0, &m_vg),
-      m_rssi("rssi", 0, units::kDecibel, "", 0, &m_vg) {
+                 m_vg),
+      m_ip_addr("ip", "", "", "", 0, m_vg),
+      m_rssi("rssi", 0, units::kDecibel, "", 0, m_vg) {
   setDependencies(&m_dependencies);
   add_link_fn([this](og3::NameToModule& name_to_module) -> bool {
     m_config = ConfigInterface::get(name_to_module);
@@ -99,7 +99,7 @@ WifiManager::WifiManager(const char* default_board_name, Tasks* tasks,
     WiFi.persistent(false);  // Keep the esp from automatically writing essid+paswd to flash.
 #endif
     if (m_config) {
-      m_config->read_config(&m_vg);
+      m_config->read_config(m_vg);
     }
 #ifdef ARDUINO_ARCH_ESP32
     m_wifiEventIdConnected = WiFi.onEvent(

--- a/test/test_config/test_config.cpp
+++ b/test/test_config/test_config.cpp
@@ -24,13 +24,13 @@ void tearDown() {}
 
 void test_config() {
   og3::VariableGroup vg("climate");
-  og3::Variable<String> loc("loc", String("home"), "", "location", og3::VariableBase::kConfig, &vg);
+  og3::Variable<String> loc("loc", String("home"), "", "location", og3::VariableBase::kConfig, vg);
   og3::FloatVariable tempC("tempC", 20.22, og3::units::kCelsius, "temperature",
-                           og3::VariableBase::kConfig, 2, &vg);
+                           og3::VariableBase::kConfig, 2, vg);
   og3::FloatVariable tempF("tempF", tempC.value() + 9 / 5 + 32, og3::units::kFahrenheit,
-                           "temperatureF", 0, 1, &vg);
+                           "temperatureF", 0, 1, vg);
   og3::DoubleVariable humidity("humidity", 60.1, og3::units::kPercentage, "humidity",
-                               og3::VariableBase::kConfig, 1, &vg);
+                               og3::VariableBase::kConfig, 1, vg);
   StdoutLogger log;
   og3::ModuleSystem ds(&log);
   og3::FlashSupport flash(&ds);
@@ -47,7 +47,7 @@ void test_config() {
   loc = "bogo";
   TEST_ASSERT_EQUAL_STRING("bogo", loc.value().c_str());
 
-  config.read_config(&vg, "test.cfg");
+  config.read_config(vg, "test.cfg");
   TEST_ASSERT_EQUAL_FLOAT(20.22f, tempC.value());
   TEST_ASSERT_EQUAL_FLOAT(0.0f, tempF.value());
   TEST_ASSERT_EQUAL_FLOAT(60.1f, humidity.value());
@@ -59,16 +59,16 @@ void test_json_parse() {
       og3::VariableBase::Flags::kConfig | og3::VariableBase::Flags::kSettable;
   og3::VariableGroup vg("watering");
   og3::FloatVariable max_moisture_target("max_moisture_target", 80.0f, og3::units::kPercentage,
-                                         "Max moisture", kCfgSet, 0, &vg);
+                                         "Max moisture", kCfgSet, 0, vg);
   og3::FloatVariable min_moisture_target("min_moisture_target", 70.0f, og3::units::kPercentage,
-                                         "Min moisture", kCfgSet, 0, &vg);
+                                         "Min moisture", kCfgSet, 0, vg);
   og3::FloatVariable pump_dose_msec("pump_on_msec", 3 * og3::kMsecInSec, og3::units::kMilliseconds,
-                                    "Pump on time", kCfgSet, 0, &vg);
-  og3::BoolVariable watering_enabled("watering_enabled", false, "watering enabled", kCfgSet, &vg);
+                                    "Pump on time", kCfgSet, 0, vg);
+  og3::BoolVariable watering_enabled("watering_enabled", false, "watering enabled", kCfgSet, vg);
   og3::BoolVariable reservoir_check_enabled("res_check_enabled", false, "reservior check enabled",
-                                            kCfgSet, &vg);
+                                            kCfgSet, vg);
   og3::FloatVariable pump_seconds_after_low("pump_after_low", 10.0f, og3::units::kSeconds,
-                                            "pump seconds after low water", kCfgSet, 0, &vg);
+                                            "pump seconds after low water", kCfgSet, 0, vg);
   const char json[] =
       "{\"soil_moisture_in_min\":2900,\"soil_moisture_in_max\":1470,\"soil_moisture_out_min\":0,"
       "\"soil_moisture_out_max\":100,\"soil_moisture_delta_per_deg\":0.075000003,\"max_moisture_"

--- a/test/test_sensor/test_sensor.cpp
+++ b/test/test_sensor/test_sensor.cpp
@@ -48,7 +48,7 @@ void test1() {
   og3::TestLogger log;
   og3::ModuleSystem modules(&log);
   og3::VariableGroup vg("vg");
-  og3::Adc adc("test", A0, &modules, "desc", 0, &vg);
+  og3::Adc adc("test", A0, &modules, "desc", 0, vg);
 
   using namespace fakeit;
   When(Method(ArduinoFake(), analogRead)).Return(0, 10);
@@ -76,7 +76,7 @@ void test2() {
           .valid_in_min = 0,
           .valid_in_max = 2050,
       },
-      &modules, &cvg, &vg);
+      &modules, cvg, vg);
 
   using namespace fakeit;
   When(Method(ArduinoFake(), analogRead)).Return(1024, 2048, (1024 + 2048) / 2, 0, 2050, 4000);
@@ -88,7 +88,7 @@ void test2() {
   mas.mapped_value().toJson(&json);
   {
     og3::VariableGroup tvg("tmp");
-    og3::FloatVariable out("out", 1.0f, "", "", 0, 0, &tvg);
+    og3::FloatVariable out("out", 1.0f, "", "", 0, 0, tvg);
     TEST_ASSERT_EQUAL_FLOAT(1.0f, out.value());
     TEST_ASSERT_TRUE(out.fromJson(json[mas.name()]));
     TEST_ASSERT_EQUAL_FLOAT(0.0f, out.value());

--- a/test/test_variables/test_variables.cpp
+++ b/test/test_variables/test_variables.cpp
@@ -14,10 +14,10 @@ void tearDown() {}
 
 void test_int_vars() {
   og3::VariableGroup vg("test1");
-  og3::Variable<int> ival("ival", 10, "", "test integer", 0, &vg);
+  og3::Variable<int> ival("ival", 10, "", "test integer", 0, vg);
   TEST_ASSERT_EQUAL_STRING("ival", ival.name());
   TEST_ASSERT_EQUAL_STRING("test integer", ival.description());
-  TEST_ASSERT_EQUAL_STRING("test1", ival.group()->name());
+  TEST_ASSERT_EQUAL_STRING("test1", ival.group().name());
   TEST_ASSERT_EQUAL(10, ival.value());
   ival = -11;
   TEST_ASSERT_EQUAL(-11, ival.value());
@@ -29,7 +29,7 @@ void test_int_vars() {
 
 void test_unsigned_vars() {
   og3::VariableGroup vg("test2");
-  og3::Variable<unsigned> uval("uval", 10, "", "test integer", 0, &vg);
+  og3::Variable<unsigned> uval("uval", 10, "", "test integer", 0, vg);
   TEST_ASSERT_EQUAL(10, uval.value());
   uval = 11;
   TEST_ASSERT_EQUAL(11, uval.value());
@@ -41,7 +41,7 @@ void test_unsigned_vars() {
 
 void test_float_vars() {
   og3::VariableGroup vg("test3");
-  og3::FloatVariable fval("fval", 10.0, "", "test float", 0, 2, &vg);
+  og3::FloatVariable fval("fval", 10.0, "", "test float", 0, 2, vg);
   TEST_ASSERT_EQUAL_FLOAT(10.0, fval.value());
   fval = 0.5;
   TEST_ASSERT_EQUAL_FLOAT(0.5, fval.value());
@@ -53,7 +53,7 @@ void test_float_vars() {
 
 void test_double_vars() {
   og3::VariableGroup vg("test4");
-  og3::DoubleVariable fval("fval", 10.0, "", "test double", 0, 2, &vg);
+  og3::DoubleVariable fval("fval", 10.0, "", "test double", 0, 2, vg);
   TEST_ASSERT_EQUAL_FLOAT(10.0, fval.value());
   fval = 0.5;
   TEST_ASSERT_EQUAL_FLOAT(0.5, fval.value());
@@ -65,7 +65,7 @@ void test_double_vars() {
 
 void test_string_vars() {
   og3::VariableGroup vg("test5");
-  og3::Variable<String> sval("sval", "default", "", "test string", 0, &vg);
+  og3::Variable<String> sval("sval", "default", "", "test string", 0, vg);
   TEST_ASSERT_EQUAL_STRING("default", sval.value().c_str());
   sval = "11";
   TEST_ASSERT_EQUAL_STRING("11", sval.value().c_str());
@@ -77,8 +77,8 @@ void test_string_vars() {
 
 void test_bool_vars() {
   og3::VariableGroup vg("bool");
-  og3::Variable<bool> bval("bval", false, "", "test bool", 0, &vg);
-  og3::BoolVariable bbval("bbval", false, "test bool2", 0, &vg);
+  og3::Variable<bool> bval("bval", false, "", "test bool", 0, vg);
+  og3::BoolVariable bbval("bbval", false, "test bool2", 0, vg);
   TEST_ASSERT_FALSE(bval.value());
   TEST_ASSERT_FALSE(bbval.value());
   bval = true;
@@ -107,11 +107,11 @@ void test_bool_vars() {
 
 void test_html_table() {
   og3::VariableGroup vg("climate");
-  og3::Variable<String> loc("loc", String("home"), "", "location", 0, &vg);
-  og3::FloatVariable tempC("tempC", 20.22, og3::units::kCelsius, "temperature", 0, 2, &vg);
+  og3::Variable<String> loc("loc", String("home"), "", "location", 0, vg);
+  og3::FloatVariable tempC("tempC", 20.22, og3::units::kCelsius, "temperature", 0, 2, vg);
   og3::FloatVariable tempF("tempF", tempC.value() + 9 / 5 + 32, og3::units::kFahrenheit,
-                           "temperatureF", 0, 1, &vg);
-  og3::DoubleVariable humidtiy("humidity", 60.1, og3::units::kPercentage, "humidity", 0, 1, &vg);
+                           "temperatureF", 0, 1, vg);
+  og3::DoubleVariable humidtiy("humidity", 60.1, og3::units::kPercentage, "humidity", 0, 1, vg);
   String html;
   og3::html::writeTableInto(&html, vg);
 #if 0


### PR DESCRIPTION
- Variables: now _must_ be part of a VariableGroup
- VariableGroup is now passed as a reference instead of as a pointer, to make it more difficult to leave out.
- Work to support HA garage/cover, and MQTT-based commands