### PR TITLE
Wifi manager: avoid empty board name

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "og3",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "description": "A library for esp projects",
     "keywords": "esp32, esp8266, modules, tasks, mqtt",
     "authors": [

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -100,7 +100,7 @@ WifiManager::WifiManager(const char* default_board_name, Tasks* tasks,
 #endif
     if (m_config) {
       m_config->read_config(m_vg);
-      if (m_board.value().isEmpty()) {
+      if (m_board.value().length() == 0) {
         m_board = "og3board";
       }
     }
@@ -180,7 +180,7 @@ void WifiManager::trySetup() {
 
   // This is a function to call to startup the board in AP mode.
   auto start_ap = [this]() {
-    const char* essid = !board().isEmpty() ? board().c_str() : "og3board";
+    const char* essid = (board().length() > 0) ? board().c_str() : "og3board";
     log()->logf("Wifi: starting in AP mode (%s).", essid);
     WiFi.mode(WIFI_AP);
     m_ap_mode = true;


### PR DESCRIPTION
A device was failing to start AP mode when the board name was set to be the empty string.

- Avoid letting board name be empty (defaults to "og3board").
- If board name is empty, default AP mode essid is `"og3board"`, not empty-string.
- Properly get IP of board in AP mode.
- Version -> 0.2.2