### PR TITLE
WifiManager: support for AP password

### DIFF
--- a/include/og3/wifi_manager.h
+++ b/include/og3/wifi_manager.h
@@ -43,6 +43,11 @@ class WifiManager : public Module {
     Options() {}
     const char* default_essid = nullptr;
     const char* default_password = nullptr;
+    const char* ap_password = nullptr;
+    Options& withApPassword(const char* pw) {
+      this->ap_password = pw;
+      return *this;
+    }
   };
 
   WifiManager(const char* default_board_name, Tasks* tasks, const Options& options = Options())
@@ -62,6 +67,7 @@ class WifiManager : public Module {
   const VariableGroup& variables() const { return m_vg; }
   VariableGroup& mutableVariables() { return m_vg; }
   const Variable<int>& rssi() const { return m_rssi; }
+  const char* ap_password() const { return m_ap_password; }
 
   void addConnectCallback(const std::function<void()>& callback) {
     m_connectCallbacks.push_back(callback);
@@ -91,6 +97,7 @@ class WifiManager : public Module {
 #endif
   SingleDependency m_dependencies;
   TaskIdScheduler m_scheduler;
+  const char* m_ap_password;
   VariableGroup m_vg;
   // Config varibles
   Variable<String> m_board;

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "og3",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "A library for esp projects",
     "keywords": "esp32, esp8266, modules, tasks, mqtt",
     "authors": [
@@ -12,7 +12,7 @@
 	}
     ],
     "dependencies": {
-	"ottowinter/AsyncMqttClient-esphome": "~0.8.5",
+	"heman/AsyncMqttClient-esphome": "~1.0.0",
 	"bblanchon/ArduinoJson": "7.0.0",
 	"esphome/ESPAsyncWebServer-esphome": "~3.0.0"
     },

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ lib_deps =
         ; This seems no longer maintained.
 	; me-no-dev/ESP Async WebServer@1.2.3
 	bblanchon/ArduinoJson@^7.0.0
-	ottowinter/AsyncMqttClient-esphome@ ^0.8.5
+	heman/AsyncMqttClient-esphome@^1.0.0
 	esphome/ESPAsyncWebServer-esphome@^3.0.0
 lib_ldf_mode = deep
 check_tool = clangtidy


### PR DESCRIPTION
Also,

- Switch to heman/AsyncMqttClient-esphome, which is used by ESPHome.
- Version -> 0.2.3