### PR TITLE
version: 0.3.10 fix kernel state

### DIFF
--- a/include/og3/kernel_filter.h
+++ b/include/og3/kernel_filter.h
@@ -49,10 +49,10 @@ class KernelFilter {
   // This could be useful for restoring state after deep sleep etc...
   template <int SZ>
   struct State {
-    unsigned long num_samples = 0;
-    float sigma = 0;
-    std::array<float, SZ> values{0.0f};
-    std::array<float, SZ> times{0.0f};
+    unsigned long num_samples;
+    float sigma;
+    std::array<float, SZ> values;
+    std::array<float, SZ> times;
   };
 
   template <int SZ>

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "og3",
-    "version": "0.3.9",
+    "version": "0.3.10",
     "description": "A library for esp projects",
     "keywords": "esp32, esp8266, modules, tasks, mqtt",
     "authors": [


### PR DESCRIPTION
Initializers in kernel state cause RTC-backed values to get overridden on wakeup from deep sleep.