### PR TITLE
version 0.3.13: Optional CRC32 for packets

### DIFF
--- a/include/og3/packet.h
+++ b/include/og3/packet.h
@@ -13,11 +13,12 @@ namespace og3::pkt {
 // ProtocolVersion    [2] major, minor
 // PktSize            [2] uint16le, includes header
 // SeqId              [2] uint16le
-// NumMsgs            [2] uint16le
+// NumMsgs            [2] uint16le (high-bit is whether there is a CRC32 at the end)
 // - Msg 0
 //   Sz               [2] uint16le, includes full msg
 //   Type             [2] uint16le: indicates kind of data.
 // -...
+// - (optional CRC32 at end) [4] uint32l3
 
 constexpr size_t kHeaderSize = 12;
 constexpr uint8_t kProtocolVersionMajor = 0x0;

--- a/include/og3/packet_reader.h
+++ b/include/og3/packet_reader.h
@@ -21,6 +21,7 @@ class PacketReader {
     kBadSize = 1,
     kBadPrefix = 2,
     kBadVersion = 3,
+    kBadCrc = 4,
   };
   static constexpr uint16_t kMaxAvailableMsgs = 16;
 
@@ -31,6 +32,7 @@ class PacketReader {
 
   uint16_t buffer_size() const { return m_buffer_size; }
   bool is_ok() const { return m_is_ok; }
+  bool has_crc() const { return m_has_crc; }
   uint8_t protocol_version_major() const { return m_protocol_version_major; }
   uint8_t protocol_version_minor() const { return m_protocol_version_minor; }
   uint16_t pkt_size() const { return m_pkt_size; }
@@ -42,6 +44,7 @@ class PacketReader {
   const uint8_t* m_buffer;
   const uint16_t m_buffer_size;
   bool m_is_ok = false;
+  bool m_has_crc = false;
   uint8_t m_protocol_version_major = 0xff;
   uint8_t m_protocol_version_minor = 0xff;
   uint16_t m_pkt_size = 0;
@@ -50,6 +53,7 @@ class PacketReader {
   uint16_t m_num_available_msgs = 0;
   uint16_t m_msg_sizes[kMaxAvailableMsgs];
   uint16_t m_msg_offsets[kMaxAvailableMsgs];
+  uint32_t m_crc = 0;
 };
 
 }  // namespace og3::pkt

--- a/include/og3/packet_writer.h
+++ b/include/og3/packet_writer.h
@@ -13,6 +13,10 @@ class PacketWriter {
   bool is_ok() const { return m_is_ok; }
   bool add_message(uint16_t type, const uint8_t* msg, uint16_t msg_size);
   uint16_t packet_size() const { return is_ok() ? m_pkt_size : 0; }
+  bool has_crc() { return 0x8000 & m_num_msgs; }
+  // Add a crc at the end of the packet.
+  // add_message() will not work on this packet after this.
+  bool add_crc();
 
  protected:
   uint8_t* m_buffer;

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "og3",
-    "version": "0.3.12",
+    "version": "0.3.13",
     "description": "A library for esp projects",
     "keywords": "esp32, esp8266, modules, tasks, mqtt",
     "authors": [
@@ -12,9 +12,10 @@
 	}
     ],
     "dependencies": {
-	"heman/AsyncMqttClient-esphome": "~1.0.0",
+	"bakercp/CRC32": "~2.0.0",
 	"bblanchon/ArduinoJson": "7.0.0",
-	"esphome/ESPAsyncWebServer-esphome": "~3.0.0"
+	"esphome/ESPAsyncWebServer-esphome": "~3.0.0",
+	"heman/AsyncMqttClient-esphome": "~1.0.0"
     },
     "export": {
 	"exclude": [".*", "*~", "util/"]

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,7 @@ lib_deps =
 	https://github.com/mathieucarbou/ESPAsyncWebServer
         ; This seems no longer maintained.
 	; me-no-dev/ESP Async WebServer@1.2.3
+	bakercp/CRC32@^2.0.0
 	bblanchon/ArduinoJson@^7.0.0
 	heman/AsyncMqttClient-esphome@^1.0.0
 	esphome/ESPAsyncWebServer-esphome@^3.0.0

--- a/test/test_packet/test_packet.cpp
+++ b/test/test_packet/test_packet.cpp
@@ -68,6 +68,7 @@ void test_packet() {
 
   og3::pkt::PacketReader reader(buffer, sizeof(buffer));
   TEST_ASSERT_EQUAL(og3::pkt::PacketReader::ParseResult::kOk, reader.parse());
+  TEST_ASSERT_FALSE(reader.has_crc());
 
   const uint8_t* pmsg = nullptr;
   uint16_t msg_type = 0;
@@ -85,8 +86,83 @@ void test_packet() {
   TEST_ASSERT_TRUE(checkmsg(msg2fn, pmsg, msg_size));
 }
 
+void test_crc() {
+  uint8_t buffer[64];
+  memset(buffer, 0, sizeof(buffer));
+  constexpr uint16_t kSeqId = 0;
+  og3::pkt::PacketWriter writer(buffer, sizeof(buffer), kSeqId);
+  TEST_ASSERT_TRUE(writer.is_ok());
+  std::array<uint8_t, 8> msg{0};
+
+  using MsgByteFn = std::function<uint8_t(uint8_t)>;
+
+  auto setmsg = [](const MsgByteFn& fn, std::array<uint8_t, 8>& msg) {
+    for (std::size_t i = 0; i < msg.size(); i++) {
+      msg[i] = fn(i);
+    }
+  };
+  auto checkmsg = [](const MsgByteFn& fn, const uint8_t* msg, std::size_t sz) -> bool {
+    for (std::size_t i = 0; i < sz; i++) {
+      if (msg[i] != fn(i)) {
+        printf("msg[%zu]:%u != expected:%u\n", i, msg[i], fn(i));
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const MsgByteFn msg1fn = [](uint8_t i) { return i; };
+  setmsg(msg1fn, msg);
+  constexpr uint16_t kMsg1Type = 0x1234;
+  TEST_ASSERT_TRUE(writer.add_message(kMsg1Type, msg.data(), msg.size()));
+
+  const MsgByteFn msg2fn = [](uint8_t i) { return 7 - i; };
+  setmsg(msg2fn, msg);
+  constexpr uint16_t kMsg2Type = 0x4321;
+  TEST_ASSERT_TRUE(writer.add_message(kMsg2Type, msg.data(), msg.size()));
+  TEST_ASSERT_TRUE(writer.add_crc());
+
+#if 0
+  for (std::size_t i = 0; i < sizeof(buffer); i++) {
+    printf(" %02x", buffer[i]);
+    if ((i + 1) % 8 == 0) {
+      printf("\n");
+    }
+  }
+#endif
+
+  og3::pkt::PacketReader reader(buffer, sizeof(buffer));
+  TEST_ASSERT_EQUAL(og3::pkt::PacketReader::ParseResult::kOk, reader.parse());
+  TEST_ASSERT_EQUAL(2, reader.num_msgs());
+  TEST_ASSERT_TRUE(reader.has_crc());
+
+  const uint8_t* pmsg = nullptr;
+  uint16_t msg_type = 0;
+  std::size_t msg_size = 0;
+  // Check msg 1
+  TEST_ASSERT_TRUE(reader.get_msg(0, &pmsg, &msg_type, &msg_size));
+  TEST_ASSERT_EQUAL(kMsg1Type, msg_type);
+  TEST_ASSERT_EQUAL(msg.size(), msg_size);
+  TEST_ASSERT_TRUE(checkmsg(msg1fn, pmsg, msg_size));
+
+#ifndef NATIVE
+  // CRC32 doesn't compile in native mode?
+  // Check msg 2
+  TEST_ASSERT_TRUE(reader.get_msg(1, &pmsg, &msg_type, &msg_size));
+  TEST_ASSERT_EQUAL(kMsg2Type, msg_type);
+  TEST_ASSERT_EQUAL(msg.size(), msg_size);
+  TEST_ASSERT_TRUE(checkmsg(msg2fn, pmsg, msg_size));
+
+  og3::pkt::PacketReader reader2(buffer, sizeof(buffer));
+  // Flip a bit in the message.
+  buffer[og3::pkt::kHeaderSize + 1] |= 0x3;
+  TEST_ASSERT_EQUAL(og3::pkt::PacketReader::ParseResult::kBadCrc, reader2.parse());
+#endif
+}
+
 int main(int argc, char** argv) {
   UNITY_BEGIN();
   RUN_TEST(test_packet);
+  RUN_TEST(test_crc);
   UNITY_END();
 }


### PR DESCRIPTION
An optional CRC32 checksum can be added to the end of packets.